### PR TITLE
Update Dockerfile to remove apt-get cache

### DIFF
--- a/noetic/Dockerfile
+++ b/noetic/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y ros-noetic-tf
 RUN echo 'source /opt/ros/noetic/setup.bash' >> ~/.bashrc
 
 # Install Git, Python pip, tf
-RUN apt-get update && apt-get install -y git python3-pykdl pip libasound2-dev
+RUN apt-get update && apt-get install -y git python3-pykdl pip libasound2-dev && rm -rf /var/lib/apt/lists/*
 
 # clone AMBF
 RUN cd  && git clone https://github.com/WPI-AIM/ambf


### PR DESCRIPTION
Removing apt-get cache to reduce image size, per Docker Best practices: https://docs.docker.com/develop/develop-images/instructions/